### PR TITLE
Proper `getName()` resolution for fixers extending `AbstractSymplifyFixer`

### DIFF
--- a/src/Fixer/AbstractSymplifyFixer.php
+++ b/src/Fixer/AbstractSymplifyFixer.php
@@ -20,7 +20,7 @@ abstract class AbstractSymplifyFixer implements FixerInterface
 
     public function getName(): string
     {
-        return self::class;
+        return static::class;
     }
 
     public function isRisky(): bool


### PR DESCRIPTION
Relates to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7064