### PR TITLE
[StandaloneLineConstructorParamFixer] Ignore constructor without arguments

### DIFF
--- a/src/TokenRunner/Analyzer/FixerAnalyzer/BlockFinder.php
+++ b/src/TokenRunner/Analyzer/FixerAnalyzer/BlockFinder.php
@@ -61,6 +61,17 @@ final class BlockFinder
             if ($token->equals(';')) {
                 return null;
             }
+
+            if ($position !== null && $token->equals('(')) {
+                $closingPosition = $tokens->getNextMeaningfulToken($position);
+                if ($closingPosition !== null) {
+                    $closingToken = $tokens[$closingPosition];
+                    if ($closingToken->equals(')')) {
+                        // function has no arguments
+                        return null;
+                    }
+                }
+            }
         }
 
         // some invalid code

--- a/tests/Fixer/Spacing/StandaloneLineConstructorParamFixer/Fixture/empty_constructor.php.inc
+++ b/tests/Fixer/Spacing/StandaloneLineConstructorParamFixer/Fixture/empty_constructor.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symplify\CodingStandard\Tests\Fixer\Spacing\StandaloneLineConstructorParamFixer\Fixture;
+
+final class EmptyConstructor
+{
+    public function __construct()
+    {
+        echo "Hello, World!";
+    }
+}
+
+?>


### PR DESCRIPTION
When you have a constructor without arguments, the fixer changes it to:

```diff
-protected function __construct() {
+protected function __construct(
+) {
```

Not sure how to solve this. Any advice?