### PR TITLE
Fix to use new docblock clearing token api in RemoveUselessDefaultCommentFixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,18 +5,18 @@
     "require": {
         "php": ">=8.2",
         "nette/utils": "^3.2",
-        "friendsofphp/php-cs-fixer": "^3.45",
+        "friendsofphp/php-cs-fixer": "^3.49",
         "symplify/rule-doc-generator-contracts": "^11.1"
     },
     "require-dev": {
-        "symplify/easy-coding-standard": "^12.0.11",
-        "squizlabs/php_codesniffer": "^3.8.0",
+        "symplify/easy-coding-standard": "^12.1",
+        "squizlabs/php_codesniffer": "^3.8.1",
         "phpunit/phpunit": "^10.5",
         "symplify/rule-doc-generator": "^12.0",
         "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan": "^1.10.50",
-        "rector/rector": "^0.18",
-        "symplify/phpstan-extensions": "^11.2",
+        "phpstan/phpstan": "^1.10.58",
+        "rector/rector": "^1.0",
+        "symplify/phpstan-extensions": "^11.4",
         "tomasvotruba/class-leak": "^0.2",
         "tracy/tracy": "^2.10"
     },

--- a/ecs.php
+++ b/ecs.php
@@ -3,19 +3,12 @@
 declare(strict_types=1);
 
 use Symplify\EasyCodingStandard\Config\ECSConfig;
-use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
-return static function (ECSConfig $ecsConfig): void {
-    $ecsConfig->paths([
-        __DIR__ . '/ecs.php',
-        __DIR__ . '/rector.php',
+return ECSConfig::configure()
+    ->withPaths([
         __DIR__ . '/config',
         __DIR__ . '/src',
         __DIR__ . '/tests',
-    ]);
-
-    $ecsConfig->sets([
-        SetList::COMMON,
-        SetList::PSR_12,
-    ]);
-};
+    ])
+    ->withRootFiles()
+    ->withPreparedSets(psr12: true, common: true);

--- a/rector.php
+++ b/rector.php
@@ -3,35 +3,13 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\Set\PHPUnitSetList;
-use Rector\Set\ValueObject\LevelSetList;
-use Rector\Set\ValueObject\SetList;
 
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_82,
-        SetList::CODE_QUALITY,
-        SetList::DEAD_CODE,
-        SetList::CODING_STYLE,
-        SetList::TYPE_DECLARATION,
-        SetList::NAMING,
-        SetList::PRIVATIZATION,
-        SetList::EARLY_RETURN,
-        PHPUnitSetList::PHPUNIT_CODE_QUALITY,
-        PHPUnitSetList::PHPUNIT_100,
-    ]);
-
-    $rectorConfig->paths([
-        __DIR__ . '/config',
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-    ]);
-
-    $rectorConfig->importNames();
-
-    $rectorConfig->skip([
-        '*/scoper.php',
+return RectorConfig::configure()
+    ->withPaths([__DIR__ . '/config', __DIR__ . '/src', __DIR__ . '/tests'])
+    ->withPhpSets()
+    ->withPreparedSets(codeQuality: true, codingStyle: true, naming: true, earlyReturn: true, privatization: true)
+    ->withImportNames(removeUnusedImports: true)
+    ->withSkip([
         '*/Source/*',
         '*/Fixture/*',
     ]);
-};

--- a/src/Fixer/Commenting/RemoveUselessDefaultCommentFixer.php
+++ b/src/Fixer/Commenting/RemoveUselessDefaultCommentFixer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\CodingStandard\Fixer\Commenting;
 
+use PhpCsFixer\Fixer\Basic\BracesFixer;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Token;
@@ -45,6 +46,12 @@ final class RemoveUselessDefaultCommentFixer extends AbstractSymplifyFixer imple
         return $tokens->isAnyTokenKindsFound([T_DOC_COMMENT, T_COMMENT]);
     }
 
+    public function getPriority(): int
+    {
+        /** must run before @see BracesFixer to cleanup spaces */
+        return 40;
+    }
+
     /**
      * @param Tokens<Token> $tokens
      */
@@ -63,13 +70,10 @@ final class RemoveUselessDefaultCommentFixer extends AbstractSymplifyFixer imple
                 $token
             );
 
-            if ($cleanedDocContent !== '') {
-                continue;
+            if ($cleanedDocContent === '') {
+                // remove token
+                $tokens->clearTokenAndMergeSurroundingWhitespace($index);
             }
-
-            // remove token
-            $tokens->clearAt($index);
-            $tokens->removeTrailingWhitespace($index, "\n");
         }
     }
 

--- a/src/Fixer/Commenting/RemoveUselessDefaultCommentFixer.php
+++ b/src/Fixer/Commenting/RemoveUselessDefaultCommentFixer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Symplify\CodingStandard\Fixer\Commenting;
 
-use PhpCsFixer\Fixer\Basic\BracesFixer;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Token;
@@ -48,7 +47,7 @@ final class RemoveUselessDefaultCommentFixer extends AbstractSymplifyFixer imple
 
     public function getPriority(): int
     {
-        /** must run before @see BracesFixer to cleanup spaces */
+        /** must run before @see \PhpCsFixer\Fixer\Basic\BracesFixer to cleanup spaces */
         return 40;
     }
 

--- a/src/Fixer/Spacing/StandaloneLineConstructorParamFixer.php
+++ b/src/Fixer/Spacing/StandaloneLineConstructorParamFixer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Symplify\CodingStandard\Fixer\Spacing;
 
-use PhpCsFixer\Fixer\Basic\BracesFixer;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Token;
@@ -36,7 +35,7 @@ final class StandaloneLineConstructorParamFixer extends AbstractSymplifyFixer im
     /**
      * Must run before
      *
-     * @see BracesFixer::getPriority()
+     * @see \PhpCsFixer\Fixer\Basic\BracesFixer::getPriority()
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Spacing/StandaloneLinePromotedPropertyFixer.php
+++ b/src/Fixer/Spacing/StandaloneLinePromotedPropertyFixer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Symplify\CodingStandard\Fixer\Spacing;
 
-use PhpCsFixer\Fixer\Basic\BracesFixer;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\CT;
@@ -37,7 +36,7 @@ final class StandaloneLinePromotedPropertyFixer extends AbstractSymplifyFixer im
     /**
      * Must run before
      *
-     * @see BracesFixer::getPriority()
+     * @see \PhpCsFixer\Fixer\Basic\BracesFixer::getPriority()
      */
     public function getPriority(): int
     {

--- a/tests/Fixer/Commenting/RemoveUselessDefaultCommentFixer/Fixture/todo_change_autogenerated_comment.php.inc
+++ b/tests/Fixer/Commenting/RemoveUselessDefaultCommentFixer/Fixture/todo_change_autogenerated_comment.php.inc
@@ -10,5 +10,6 @@ namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RemovePHPStormTodoComme
 
 namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RemovePHPStormTodoCommentFixer\Fixture;
 
+
 // TODO some other notes
 ?>

--- a/tests/Fixer/Commenting/RemoveUselessDefaultCommentFixer/Fixture/useless_class_comment.php.inc
+++ b/tests/Fixer/Commenting/RemoveUselessDefaultCommentFixer/Fixture/useless_class_comment.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RemoveUselessClassCommentFixer\Fixture;
+namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RemoveUselessDefaultCommentFixer\Fixture;
 
 /**
  * class SomeClass
@@ -36,23 +36,28 @@ class SomeClass5
 -----
 <?php
 
-namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RemoveUselessClassCommentFixer\Fixture;
+namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RemoveUselessDefaultCommentFixer\Fixture;
+
 
 class SomeClass1
 {
 }
 
+
 class SomeClass2
 {
 }
+
 
 class SomeClass3
 {
 }
 
+
 class SomeClass4
 {
 }
+
 
 class SomeClass5
 {

--- a/tests/Issues/config/config_remove_useless_default_comment_and_statement_indentation.php
+++ b/tests/Issues/config/config_remove_useless_default_comment_and_statement_indentation.php
@@ -2,11 +2,15 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\Basic\BracesFixer;
 use PhpCsFixer\Fixer\Whitespace\StatementIndentationFixer;
 use Symplify\CodingStandard\Fixer\Commenting\RemoveUselessDefaultCommentFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 return static function (ECSConfig $ecsConfig): void {
-    $ecsConfig->rule(RemoveUselessDefaultCommentFixer::class);
-    $ecsConfig->rule(StatementIndentationFixer::class);
+    $ecsConfig->rules([
+        BracesFixer::class,
+        RemoveUselessDefaultCommentFixer::class,
+        StatementIndentationFixer::class,
+    ]);
 };

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,14 +21,12 @@ if (! defined('T_ENUM')) {
     define('T_ENUM', 5015);
 }
 
-
 // required for PHP_CodeSniffer in packages/EasyCodingStandard/tests/*
 if (! defined('PHP_CODESNIFFER_VERBOSITY')) {
     define('PHP_CODESNIFFER_VERBOSITY', 0);
     // initialize custom T_* token constants used by PHP_CodeSniffer parser
     new Tokens();
 }
-
 
 // prefer local coding-standard over old, vendor one
 exec('rm -rf vendor/symplify/easy-coding-standard/vendor/symplify/coding-standard/src');


### PR DESCRIPTION
Closes https://github.com/easy-coding-standard/easy-coding-standard/issues/174