### PR TITLE
StandaloneLinePromotedPropertyFixer should apply when there's only one promoted property.

### DIFF
--- a/src/TokenRunner/Transformer/FixerTransformer/TokensNewliner.php
+++ b/src/TokenRunner/Transformer/FixerTransformer/TokensNewliner.php
@@ -50,7 +50,7 @@ final readonly class TokensNewliner
         );
 
         // again, from the bottom to the top
-        for ($i = $blockInfo->getEnd() - 1; $i > $blockInfo->getStart(); --$i) {
+        for ($i = $blockInfo->getEnd() - 1; $i >= $blockInfo->getStart(); --$i) {
             /** @var Token $currentToken */
             $currentToken = $tokens[$i];
 

--- a/tests/Fixer/Spacing/StandaloneLinePromotedPropertyFixer/Fixture/promoted_property.php.inc
+++ b/tests/Fixer/Spacing/StandaloneLinePromotedPropertyFixer/Fixture/promoted_property.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Symplify\CodingStandard\Tests\Fixer\Spacing\StandaloneLinePromotedPropertyFixer\Fixture;
+
+final class PromotedProperties
+{
+    public function __construct(public int $age)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Symplify\CodingStandard\Tests\Fixer\Spacing\StandaloneLinePromotedPropertyFixer\Fixture;
+
+final class PromotedProperties
+{
+    public function __construct(
+        public int $age
+    )
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
Fixes #43 