### PR TITLE
[TokenRunner] Handle crash on BlockFinder when using LineLengthFixer + NewWithParenthesesFixer

### DIFF
--- a/src/TokenRunner/Analyzer/FixerAnalyzer/BlockFinder.php
+++ b/src/TokenRunner/Analyzer/FixerAnalyzer/BlockFinder.php
@@ -54,6 +54,11 @@ final class BlockFinder
 
         if ($token->isGivenKind([T_FUNCTION, CT::T_USE_LAMBDA, T_NEW])) {
             $position = $tokens->getNextTokenOfKind($position, ['(', ';']);
+
+            if ($position === null) {
+                return null;
+            }
+
             /** @var Token $token */
             $token = $tokens[$position];
 

--- a/tests/Issues/Fixture/line_length_parentheses.php.inc
+++ b/tests/Issues/Fixture/line_length_parentheses.php.inc
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+final class LineLengtParentheses
+{
+    public function __construct(
+        private DateTimeImmutable $dateTimeImmutable = new DateTimeImmutable()
+    ) {}
+}
+
+?>
+-----
+<?php declare(strict_types=1);
+
+final class LineLengtParentheses
+{
+    public function __construct(
+        private DateTimeImmutable $dateTimeImmutable = new DateTimeImmutable
+    ) {}
+}
+
+?>

--- a/tests/Issues/LineLengthParenthesesTest.php
+++ b/tests/Issues/LineLengthParenthesesTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Tests\Issues;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
+
+final class LineLengthParenthesesTest extends AbstractCheckerTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/line_length_parentheses.php.inc'];
+    }
+
+    public function provideConfig(): string
+    {
+        return __DIR__ . '/config/line_length_parentheses.php';
+    }
+}

--- a/tests/Issues/config/line_length_parentheses.php
+++ b/tests/Issues/config/line_length_parentheses.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Fixer\Operator\NewWithParenthesesFixer;
+use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rules([
+        LineLengthFixer::class,
+    ]);
+
+    $ecsConfig->ruleWithConfiguration(NewWithParenthesesFixer::class, [
+        'anonymous_class' => false,
+        'named_class' => false,
+    ]);
+};


### PR DESCRIPTION
Fixes https://github.com/easy-coding-standard/easy-coding-standard/issues/199