### PR TITLE
Bump to nette/utils ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.2",
-        "nette/utils": "^3.2",
+        "nette/utils": "^4.0",
         "friendsofphp/php-cs-fixer": "^3.59",
         "symplify/rule-doc-generator-contracts": "^11.2"
     },


### PR DESCRIPTION
Ref https://github.com/easy-coding-standard/easy-coding-standard/pull/224

It require release first to allow easy-coding-standard bump to v4 as well.