### PR TITLE
Fix function spelling

### DIFF
--- a/src/Fixer/Spacing/MethodChainingNewlineFixer.php
+++ b/src/Fixer/Spacing/MethodChainingNewlineFixer.php
@@ -119,7 +119,7 @@ final class MethodChainingNewlineFixer extends AbstractSymplifyFixer
      *
      * @param Tokens<Token> $tokens
      */
-    private function isPreceededByOpenedCallInAnotherBracket(Tokens $tokens, int $position): bool
+    private function isPrecededByOpenedCallInAnotherBracket(Tokens $tokens, int $position): bool
     {
         $blockInfo = $this->blockFinder->findInTokensByEdge($tokens, $position);
         if (! $blockInfo instanceof BlockInfo) {
@@ -142,11 +142,11 @@ final class MethodChainingNewlineFixer extends AbstractSymplifyFixer
             return false;
         }
 
-        if ($this->chainMethodCallAnalyzer->isPreceededByFuncCall($tokens, $position)) {
+        if ($this->chainMethodCallAnalyzer->isPrecededByFuncCall($tokens, $position)) {
             return false;
         }
 
-        if ($this->isPreceededByOpenedCallInAnotherBracket($tokens, $position)) {
+        if ($this->isPrecededByOpenedCallInAnotherBracket($tokens, $position)) {
             return false;
         }
 

--- a/src/TokenAnalyzer/ChainMethodCallAnalyzer.php
+++ b/src/TokenAnalyzer/ChainMethodCallAnalyzer.php
@@ -21,8 +21,20 @@ final class ChainMethodCallAnalyzer
      * Matches e.g: return app()->some(), app()->some(), (clone app)->some()
      *
      * @param Tokens<Token> $tokens
+     *
+     * @deprecated use isPrecededByFuncCall() instead.
      */
     public function isPreceededByFuncCall(Tokens $tokens, int $position): bool
+    {
+        return $this->isPrecededByFuncCall($tokens, $position);
+    }
+
+    /**
+     * Matches e.g: return app()->some(), app()->some(), (clone app)->some()
+     *
+     * @param Tokens<Token> $tokens
+     */
+    public function isPrecededByFuncCall(Tokens $tokens, int $position): bool
     {
         for ($i = $position; $i >= 0; --$i) {
             /** @var Token $currentToken */

--- a/src/TokenAnalyzer/ChainMethodCallAnalyzer.php
+++ b/src/TokenAnalyzer/ChainMethodCallAnalyzer.php
@@ -21,18 +21,6 @@ final class ChainMethodCallAnalyzer
      * Matches e.g: return app()->some(), app()->some(), (clone app)->some()
      *
      * @param Tokens<Token> $tokens
-     *
-     * @deprecated use isPrecededByFuncCall() instead.
-     */
-    public function isPreceededByFuncCall(Tokens $tokens, int $position): bool
-    {
-        return $this->isPrecededByFuncCall($tokens, $position);
-    }
-
-    /**
-     * Matches e.g: return app()->some(), app()->some(), (clone app)->some()
-     *
-     * @param Tokens<Token> $tokens
      */
     public function isPrecededByFuncCall(Tokens $tokens, int $position): bool
     {


### PR DESCRIPTION
I have marked `isPreceededByFuncCall` as deprecated, so it don't break anyone's code.