### PR TITLE
[Annotation] Skip multiple @var on variable definition on RemovePropertyVariableNameDescriptionFixer

### DIFF
--- a/src/Fixer/Annotation/RemovePropertyVariableNameDescriptionFixer.php
+++ b/src/Fixer/Annotation/RemovePropertyVariableNameDescriptionFixer.php
@@ -75,6 +75,12 @@ final class RemovePropertyVariableNameDescriptionFixer extends AbstractSymplifyF
             // skip if not setter or getter
             $originalDocContent = $token->getContent();
 
+            preg_match_all(self::VAR_REGEX, $originalDocContent, $matches);
+
+            if (isset($matches[0]) && is_array($matches[0]) && count($matches[0]) !== 1) {
+                continue;
+            }
+
             $hasChanged = false;
 
             $docblockLines = explode("\n", $originalDocContent);

--- a/src/Fixer/Annotation/RemovePropertyVariableNameDescriptionFixer.php
+++ b/src/Fixer/Annotation/RemovePropertyVariableNameDescriptionFixer.php
@@ -77,7 +77,7 @@ final class RemovePropertyVariableNameDescriptionFixer extends AbstractSymplifyF
 
             preg_match_all(self::VAR_REGEX, $originalDocContent, $matches);
 
-            if (isset($matches[0]) && is_array($matches[0]) && count($matches[0]) !== 1) {
+            if (count($matches[0]) !== 1) {
                 continue;
             }
 

--- a/tests/Fixer/Annotation/RemovePropertyVariableNameDescriptionFixer/Fixture/skip_multiple_var.php.inc
+++ b/tests/Fixer/Annotation/RemovePropertyVariableNameDescriptionFixer/Fixture/skip_multiple_var.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symplify\CodingStandard\Tests\Fixer\Annotation\RemovePropertyVariableNameDescriptionFixer\Fixture;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+
+final class SkipMultipleVar
+{
+    public function run()
+    {
+        /**
+         * @var FuncCall $firstArgumentValue
+         * @var array<Arg> $args
+         **/
+        $args = $firstArgumentValue->getArgs();
+    }
+}
+
+?>

--- a/tests/Fixer/Annotation/RemovePropertyVariableNameDescriptionFixer/Fixture/skip_multiple_var.php.inc
+++ b/tests/Fixer/Annotation/RemovePropertyVariableNameDescriptionFixer/Fixture/skip_multiple_var.php.inc
@@ -16,5 +16,3 @@ final class SkipMultipleVar
         $args = $firstArgumentValue->getArgs();
     }
 }
-
-?>


### PR DESCRIPTION
Ref https://github.com/symplify/coding-standard/pull/68#issuecomment-2888334277