### PR TITLE
[ArrayNotation] Skip Interpolation string on ArrayListItemNewlineFixer

### DIFF
--- a/src/TokenRunner/Arrays/ArrayItemNewliner.php
+++ b/src/TokenRunner/Arrays/ArrayItemNewliner.php
@@ -46,6 +46,10 @@ final readonly class ArrayItemNewliner
                     return;
                 }
 
+                if ($nextToken->getContent() === '{') {
+                    return;
+                }
+
                 $tokens->ensureWhitespaceAtIndex($nextTokenPosition, 0, $this->whitespacesFixerConfig->getLineEnding());
             }
         );

--- a/tests/Fixer/ArrayNotation/ArrayListItemNewlineFixer/Fixture/skip_interpolated_string.php.inc
+++ b/tests/Fixer/ArrayNotation/ArrayListItemNewlineFixer/Fixture/skip_interpolated_string.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symplify\CodingStandard\Tests\Fixer\ArrayNotation\ArrayListItemNewlineFixer\Fixture;
+
+final class SkipInterpolatedString
+{
+    public function run()
+    {
+        $a = 'A';
+        $b = 'B';
+
+        return [
+            'text' => "{$a},{$b}",
+        ];
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/symplify/coding-standard/issues/59