### PR TITLE
[Commenting] Skip Nested multiline array<> on ParamReturnAndVarTagMalformsFixer

### DIFF
--- a/src/TokenRunner/DocBlock/MalformWorker/MissingParamNameMalformWorker.php
+++ b/src/TokenRunner/DocBlock/MalformWorker/MissingParamNameMalformWorker.php
@@ -16,9 +16,9 @@ final readonly class MissingParamNameMalformWorker implements MalformWorkerInter
 {
     /**
      * @var string
-     * @see https://regex101.com/r/QtWnWv/5
+     * @see https://regex101.com/r/QtWnWv/6
      */
-    private const PARAM_WITHOUT_NAME_REGEX = '#@param ([^${]*?)( ([^$]*?))?\n#';
+    private const PARAM_WITHOUT_NAME_REGEX = '#@param ([^${<]*?)( ([^$]*?))?\n#';
 
     /**
      * @var string

--- a/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Fixture/skip_nested_multiline.php.inc
+++ b/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Fixture/skip_nested_multiline.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @param array<string, array{
+ *     foo: string
+ * }> $foo
+ */
+function test($foo, $bar): void
+{
+
+}


### PR DESCRIPTION
Fixes https://github.com/symplify/coding-standard/issues/49