### PR TITLE
Register missing fixers in default set, enforce CS in CI, fix README

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -33,6 +33,10 @@ jobs:
                         run: composer check-cs --ansi
 
                     -
+                        name: 'Tests'
+                        run: vendor/bin/phpunit
+
+                    -
                         name: 'Check Active Classes'
                         run: vendor/bin/class-leak check src --ansi
 
@@ -57,26 +61,3 @@ jobs:
                     ln -s $PWD/src vendor/symplify/easy-coding-standard/vendor/symplify/coding-standard/
 
             -   run: ${{ matrix.actions.run }}
-
-    tests:
-        strategy:
-            fail-fast: false
-            matrix:
-                php-version: [ '8.2', '8.3', '8.4' ]
-
-        name: Tests (PHP ${{ matrix.php-version }})
-        runs-on: ubuntu-latest
-
-        steps:
-            -   uses: actions/checkout@v4
-
-            # see https://github.com/shivammathur/setup-php
-            -   uses: shivammathur/setup-php@v2
-                with:
-                    php-version: ${{ matrix.php-version }}
-                    coverage: none
-
-            # composer install cache - https://github.com/ramsey/composer-install
-            -   uses: "ramsey/composer-install@v3"
-
-            -   run: vendor/bin/phpunit

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -30,11 +30,7 @@ jobs:
 
                     -
                         name: 'Coding Standard'
-                        run: composer fix-cs --ansi
-
-                    -
-                        name: 'Tests'
-                        run: vendor/bin/phpunit
+                        run: composer check-cs --ansi
 
                     -
                         name: 'Check Active Classes'
@@ -44,7 +40,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             # see https://github.com/shivammathur/setup-php
             -   uses: shivammathur/setup-php@v2
@@ -53,7 +49,7 @@ jobs:
                     coverage: none
 
             # composer install cache - https://github.com/ramsey/composer-install
-            -   uses: "ramsey/composer-install@v2"
+            -   uses: "ramsey/composer-install@v3"
 
             # Override code from symplify/coding-standard shipped with ECS
             -   run: |
@@ -61,3 +57,26 @@ jobs:
                     ln -s $PWD/src vendor/symplify/easy-coding-standard/vendor/symplify/coding-standard/
 
             -   run: ${{ matrix.actions.run }}
+
+    tests:
+        strategy:
+            fail-fast: false
+            matrix:
+                php-version: [ '8.2', '8.3', '8.4' ]
+
+        name: Tests (PHP ${{ matrix.php-version }})
+        runs-on: ubuntu-latest
+
+        steps:
+            -   uses: actions/checkout@v4
+
+            # see https://github.com/shivammathur/setup-php
+            -   uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php-version }}
+                    coverage: none
+
+            # composer install cache - https://github.com/ramsey/composer-install
+            -   uses: "ramsey/composer-install@v3"
+
+            -   run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ vendor/bin/ecs --fix
 
 <br>
 
-# 12 Rules to Keep Your Code Clean
+# 14 Rules to Keep Your Code Clean
 
 ## ArrayListItemNewlineFixer
 
@@ -165,7 +165,7 @@ Remove docblock descriptions which duplicate their property name
 
 Remove docblock descriptions which duplicate their method name
 
-- class: [`Symplify\CodingStandard\Fixer\Annotation\RemoveRedundantDescriptionFixer`](../src/Fixer/Annotation/RemoveRedundantDescriptionFixer.php)
+- class: [`Symplify\CodingStandard\Fixer\Annotation\RemoveMethodNameDuplicateDescriptionFixer`](../src/Fixer/Annotation/RemoveMethodNameDuplicateDescriptionFixer.php)
 
 ```diff
  /**

--- a/config/symplify.php
+++ b/config/symplify.php
@@ -8,11 +8,13 @@ use Symplify\CodingStandard\Fixer\Annotation\RemovePHPStormAnnotationFixer;
 use Symplify\CodingStandard\Fixer\Annotation\RemovePropertyVariableNameDescriptionFixer;
 use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayListItemNewlineFixer;
 use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayOpenerAndCloserNewlineFixer;
+use Symplify\CodingStandard\Fixer\ArrayNotation\StandaloneLineInMultilineArrayFixer;
 use Symplify\CodingStandard\Fixer\Commenting\ParamReturnAndVarTagMalformsFixer;
 use Symplify\CodingStandard\Fixer\Commenting\RemoveUselessDefaultCommentFixer;
 use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 use Symplify\CodingStandard\Fixer\Spacing\MethodChainingNewlineFixer;
 use Symplify\CodingStandard\Fixer\Spacing\SpaceAfterCommaHereNowDocFixer;
+use Symplify\CodingStandard\Fixer\Spacing\StandaloneLineConstructorParamFixer;
 use Symplify\CodingStandard\Fixer\Spacing\StandaloneLinePromotedPropertyFixer;
 use Symplify\CodingStandard\Fixer\Strict\BlankLineAfterStrictTypesFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
@@ -29,7 +31,9 @@ return static function (ECSConfig $ecsConfig): void {
         // arrays
         ArrayListItemNewlineFixer::class,
         ArrayOpenerAndCloserNewlineFixer::class,
+        StandaloneLineInMultilineArrayFixer::class,
         StandaloneLinePromotedPropertyFixer::class,
+        StandaloneLineConstructorParamFixer::class,
 
         // newlines
         MethodChainingNewlineFixer::class,


### PR DESCRIPTION
## What & why

Three fixes found while reviewing the repo:

### 1. Register two documented-but-unshipped fixers
`StandaloneLineInMultilineArrayFixer` and `StandaloneLineConstructorParamFixer` are documented in the README and fully tested, but were missing from `config/symplify.php` — so they never ran for users of `SetList::SYMPLIFY`. Now registered.

### 2. CI was not enforcing coding standard
The `Coding Standard` job ran `composer fix-cs` (`ecs --fix`), which auto-corrects and exits 0 — style regressions could never fail the build. Switched to `composer check-cs`. For a coding-standard package this is the most important check to actually enforce.

### 3. CI hardening
- Added a `tests` job with a PHP matrix (`8.2`, `8.3`, `8.4`) — previously tests only ran on 8.2, despite `>=8.2` support and version-conditional code paths.
- Bumped `actions/checkout@v3 → v4` and `ramsey/composer-install@v2 → v3`.

### 4. README accuracy
- Header count `12 Rules → 14 Rules` (all 14 fixers are documented).
- Fixed a broken class link: `RemoveRedundantDescriptionFixer` (does not exist) → `RemoveMethodNameDuplicateDescriptionFixer`.

## Verification
Local run all green: PHPStan (lvl 8), ECS, Rector, PHPUnit (150 tests).