### PR TITLE
README: mark package deprecated, point to ECS

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -55,9 +55,4 @@ jobs:
             # composer install cache - https://github.com/ramsey/composer-install
             -   uses: "ramsey/composer-install@v3"
 
-            # Override code from symplify/coding-standard shipped with ECS
-            -   run: |
-                    rm -rf vendor/symplify/easy-coding-standard/vendor/symplify/coding-standard/src
-                    ln -s $PWD/src vendor/symplify/easy-coding-standard/vendor/symplify/coding-standard/
-
             -   run: ${{ matrix.actions.run }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Downloads](https://img.shields.io/packagist/dt/symplify/coding-standard.svg?style=flat-square)](https://packagist.org/packages/symplify/coding-standard/stats)
 
+> [!WARNING]
+> **This package is deprecated.** Use [Easy Coding Standard (ECS)](https://github.com/easy-coding-standard/easy-coding-standard) instead, where these rules and coding standard work out of the box—no extra setup needed.
+
 Coding standard rules for clean, consistent, and readable PHP code. No configuration needed—just install and let it handle the rest.
 
 They run best with [ECS](https://github.com/symplify/easy-coding-standard).


### PR DESCRIPTION
Mark `symplify/coding-standard` as deprecated. Point users to [Easy Coding Standard](https://github.com/easy-coding-standard/easy-coding-standard) where the coding standard works out of the box.